### PR TITLE
Fix subMethod to support coffees's @

### DIFF
--- a/upgrade.py
+++ b/upgrade.py
@@ -53,8 +53,8 @@ def subString(search, replace):
   sub(searchTermD, replaceTermD)
 
 def subMethod(search, replace):
-  searchTerm = "'.%s\\('" % (search)
-  replaceTerm  = "'.%s('" % (replace)
+  searchTerm = "'(\.|@)%s\\('" % (search)
+  replaceTerm  = "'\\1%s('" % (replace)
   sub(searchTerm, replaceTerm)
 
 def subEvent(search, replace):


### PR DESCRIPTION
Escape `.` in searchTerm to avoid matching non-dot characters and keep
the original prefix:
  .close() -> .destroy()
  @close() -> @destroy()

Closes #21
